### PR TITLE
add pkg_commands.d file for centos

### DIFF
--- a/plugins/pkg_commands.d/centos
+++ b/plugins/pkg_commands.d/centos
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# CentOS uses yum/dnf or rpm-ostree(edge images) as the package command
+if [[ -x /run/ostree-booted ]]; then
+    RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-rpm-ostree}
+    RSTRNT_PKG_ARGS=${RSTRNT_PKG_ARGS:-A --idempotent --allow-inactive}
+fi


### PR DESCRIPTION
Stream os-tree deployment is not able to support yum/dnf install of packages.
Still blocked by soft dependency install through restraint, as restraint sees the rpm-ostree error as a failure.