### PR TITLE
Fix `rstrnt-reboot` reliability of UEFI systems

### DIFF
--- a/scripts/rstrnt-prepare-reboot
+++ b/scripts/rstrnt-prepare-reboot
@@ -30,10 +30,12 @@ if efibootmgr &>/dev/null ; then
     if [[ -n "$os_boot_entry" ]] ; then
         logger -s "efibootmgr -n $os_boot_entry"
         efibootmgr -n $os_boot_entry
-        create_nextboot_timer
-        # Adjust watchdog if running inside of test case
-        if [[ -n $RSTRNT_RECIPE_URL && $RSTRNT_MAXTIME ]] ; then
-            rstrnt-adjust-watchdog $(($RSTRNT_MAXTIME + $NEXTBOOT_VALID_TIME))
+        if [[ -z "$REGULAR_REBOOT" ]]; then
+            create_nextboot_timer
+            # Adjust watchdog if running inside of test case
+            if [[ -n $RSTRNT_RECIPE_URL && $RSTRNT_MAXTIME ]] ; then
+                rstrnt-adjust-watchdog $(($RSTRNT_MAXTIME + $NEXTBOOT_VALID_TIME))
+            fi
         fi
     else
         logger -s "Could not determine value for BootNext!"

--- a/scripts/rstrnt-reboot
+++ b/scripts/rstrnt-reboot
@@ -12,7 +12,7 @@ trap "" SIGTERM
 
 PATH=/sbin:/usr/sbin:$PATH
 
-/usr/bin/rstrnt-prepare-reboot
+REGULAR_REBOOT=y /usr/bin/rstrnt-prepare-reboot
 shutdown -r now
 
 # Wait for the shutdown to kill us.  Sleep to avoid returning


### PR DESCRIPTION
Do not reset `BootNext` on UEFI to previous value after 180s as that is the expected behaviour according to the documentation and fix compatibility with `rhts-reboot`.

Fixes: 11facdcfa06dbe43663107d12d65c001d8dc55fc