### PR TITLE
libarchive requires bzip2 compiled with -fPIE

### DIFF
--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -77,7 +77,7 @@ tree/lib/pkgconfig/openssl.pc: $(OPENSSL)
 	$(MAKE) -C $(OPENSSL)
 	$(MAKE) -C $(OPENSSL) PREFIX=$(CURDIR)/tree install_sw
 
-tree/lib/libbz2.a: $(BZIP2)
+tree/lib/libbz2.a: $(BZIP2) $(BZIP2)/.patches-done
 	$(MAKE) -C $(BZIP2)
 	$(MAKE) -C $(BZIP2) PREFIX=$(CURDIR)/tree install
 
@@ -150,6 +150,10 @@ tree/lib/pkgconfig/libarchive.pc: $(LIBARCHIVE) $(LIBARCHIVE)/.patches-done \
 	    --enable-static --disable-shared --without-zstd )
 	$(MAKE) -C $(LIBARCHIVE)
 	$(MAKE) -C $(LIBARCHIVE) install
+
+$(BZIP2)/.patches-done: $(BZIP2)
+	patch -d$(BZIP2) -p1 <bzip2-add-fPIE.patch
+	touch $@
 
 $(LIBARCHIVE)/.patches-done: $(LIBARCHIVE)
 	patch -d$(LIBARCHIVE) -p1 <libarchive-use-pkgconfig.patch

--- a/third-party/bzip2-add-fPIE.patch
+++ b/third-party/bzip2-add-fPIE.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index f8a1772..f798668 100644
+--- a/Makefile
++++ b/Makefile
+@@ -21,7 +21,7 @@ RANLIB=ranlib
+ LDFLAGS=
+ 
+ BIGFILES=-D_FILE_OFFSET_BITS=64
+-CFLAGS=-Wall -Winline -O2 -g $(BIGFILES)
++CFLAGS=-fPIE -Wall -Winline -O2 -g $(BIGFILES)
+ 
+ # Where you want it installed when you do 'make install'
+ PREFIX=/usr/local


### PR DESCRIPTION
Trying to build latest rawhide rpms for restraint.  Discovered
Fedora-36 and 37 were not building. Build system showed errors
from libarchive builds with undefined references to methods
like BZ2_bzDecompressInit, BZ2_bzDecompress, etc.  Outside
of build system, I found errors requesting the bzip2 library
be recompiled with -fPIE which is what this changeset does.
Once changes applied, build errors went away and the
executable comes up and runs without issues.