### PR TITLE
Quote variable usage in 01_dmesg_check

### DIFF
--- a/plugins/report_result.d/01_dmesg_check
+++ b/plugins/report_result.d/01_dmesg_check
@@ -31,36 +31,36 @@ OUTPUTFILE=$TMPDIR/outputfile.log
 # 2) else use content of failure or falsestrings files
 # 3) else use hardcoded defaults.
 FAILUREFILENM=${FAILUREFILENM:-"/usr/share/rhts/failurestrings"}
-if [ ! -s ${FAILUREFILENM} ]; then
-    if [ -z ${FAILURESTRINGS} ]; then
+if [ ! -s "${FAILUREFILENM}" ]; then
+    if [ -z "${FAILURESTRINGS}" ]; then
         DMESG_FAIL_SELECTOR="Default FAILURESTRINGS"
         FAILURESTRINGS="Oops|BUG|NMI appears to be stuck|Badness at"
     else
         DMESG_FAIL_SELECTOR="FAILURESTRINGS Environment Variable"
     fi
 else
-    if [ -z ${FAILURESTRINGS} ]; then
+    if [ -z "${FAILURESTRINGS}" ]; then
         DMESG_FAIL_SELECTOR="failurestrings file"
         # Remove space filled or empty lines and join lines with "|"
-        FAILURESTRINGS=$(sed '/^ *$/d' ${FAILUREFILENM} | paste -sd "|")
+        FAILURESTRINGS=$(sed '/^ *$/d' "${FAILUREFILENM}" | paste -sd "|")
     else
         DMESG_FAIL_SELECTOR="FAILURESTRINGS Environment Variable"
     fi
 fi
 
 FALSEFILENM=${FALSEFILENM:-"/usr/share/rhts/falsestrings"}
-if [ ! -s ${FALSEFILENM} ]; then
-    if [ -z ${FALSESTRINGS} ]; then
+if [ ! -s "${FALSEFILENM}" ]; then
+    if [ -z "${FALSESTRINGS}" ]; then
         DMESG_FALSE_SELECTOR="Default FALSESTRINGS"
         FALSESTRINGS="BIOS BUG|DEBUG|mapping multiple BARs.*IBM System X3250 M4"
     else
         DMESG_FALSE_SELECTOR="FALSESTRINGS Environment Variable"
     fi
 else
-    if [ -z ${FALSESTRINGS} ]; then
+    if [ -z "${FALSESTRINGS}" ]; then
         DMESG_FALSE_SELECTOR="falsestrings file"
         # Remove space filled or empty lines and join lines with "|"
-        FALSESTRINGS=$(sed '/^ *$/d' ${FALSEFILENM} | paste -sd "|")
+        FALSESTRINGS=$(sed '/^ *$/d' "${FALSEFILENM}" | paste -sd "|")
     else
         DMESG_FALSE_SELECTOR="FALSESTRINGS Environment Variable"
     fi
@@ -93,33 +93,33 @@ grep -E -v "$FALSESTRINGS" "$DMESG_FILE" | grep -E "$FAILURESTRINGS" >> "$OUTPUT
 
 if [ -s "$OUTPUTFILE" ]; then
     # print FAILURE/FALSESTRINGS used at bottom of file
-    echo -e "====================================================" >> ${OUTPUTFILE}
-    echo -e "DMESG Selectors:" >> ${OUTPUTFILE}
-    echo -e "Used $DMESG_FAIL_SELECTOR and $DMESG_FALSE_SELECTOR" >> ${OUTPUTFILE}
-    echo -e "====================================================" >> ${OUTPUTFILE}
-    echo -e "FAILURESTRINGS: ${FAILURESTRINGS}" >> ${OUTPUTFILE}
-    if [ -f ${FAILUREFILENM} ]; then
-        if [ -s ${FAILUREFILENM} ]; then
-            echo -e "FailureStrings file found and contains:" >> ${OUTPUTFILE}
-            cat ${FAILUREFILENM} >> ${OUTPUTFILE}
+    echo -e "====================================================" >> "${OUTPUTFILE}"
+    echo -e "DMESG Selectors:" >> "${OUTPUTFILE}"
+    echo -e "Used $DMESG_FAIL_SELECTOR and $DMESG_FALSE_SELECTOR" >> "${OUTPUTFILE}"
+    echo -e "====================================================" >> "${OUTPUTFILE}"
+    echo -e "FAILURESTRINGS: ${FAILURESTRINGS}" >> "${OUTPUTFILE}"
+    if [ -f "${FAILUREFILENM}" ]; then
+        if [ -s "${FAILUREFILENM}" ]; then
+            echo -e "FailureStrings file found and contains:" >> "${OUTPUTFILE}"
+            cat "${FAILUREFILENM}" >> "${OUTPUTFILE}"
         else
-            echo -e "FailureStrings file found but empty." >> ${OUTPUTFILE}
+            echo -e "FailureStrings file found but empty." >> "${OUTPUTFILE}"
         fi
     else
-        echo -e "FailureStrings file not found." >> ${OUTPUTFILE}
+        echo -e "FailureStrings file not found." >> "${OUTPUTFILE}"
     fi
-    echo -e "====================================================" >> ${OUTPUTFILE}
-    echo -e "FALSESTRINGS: ${FALSESTRINGS}" >> ${OUTPUTFILE}
-    if [ -f ${FALSEFILENM} ]; then
-        if [ -s ${FALSEFILENM} ]; then
-            echo -e "FalseStrings file found and contains:" >> ${OUTPUTFILE}
-            cat ${FALSEFILENM} >> ${OUTPUTFILE}
+    echo -e "====================================================" >> "${OUTPUTFILE}"
+    echo -e "FALSESTRINGS: ${FALSESTRINGS}" >> "${OUTPUTFILE}"
+    if [ -f "${FALSEFILENM}" ]; then
+        if [ -s "${FALSEFILENM}" ]; then
+            echo -e "FalseStrings file found and contains:" >> "${OUTPUTFILE}"
+            cat "${FALSEFILENM}" >> "${OUTPUTFILE}"
         else
-            echo -e "FalseStrings file found but empty." >> ${OUTPUTFILE}
+            echo -e "FalseStrings file found but empty." >> "${OUTPUTFILE}"
         fi
     else
-        echo -e "FalseStrings file not found." >> ${OUTPUTFILE}
+        echo -e "FalseStrings file not found." >> "${OUTPUTFILE}"
     fi
-    echo -e "====================================================" >> ${OUTPUTFILE}
+    echo -e "====================================================" >> "${OUTPUTFILE}"
     OUTPUTFILE=$OUTPUTFILE rstrnt-report-result --no-plugins "$TEST"/"$PLUGIN" FAIL 0
 fi


### PR DESCRIPTION
In restraintd log files saw the following:
  May 18 09:26:56 system1.example.com restraintd[2330]: ./01_dmesg_check: line 53: [: too many arguments

We are setting the `FALSESTRINGS` variable and the `|` symbols in the
value are interpreted by bash. Quote the value to prevent this.