### PR TITLE
Fix: Upgrade ZLIB to zlib-1.2.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@
 /third-party/zlib-1.2.11/
 /third-party/zlib-1.2.12.tar.gz
 /third-party/zlib-1.2.12/
+/third-party/zlib-1.2.13.tar.gz
+/third-party/zlib-1.2.13/
 /third-party/autoconf-2.69.tar.gz
 /third-party/autoconf-2.69/
 /third-party/json-c-0.13.1.tar.gz

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -53,7 +53,7 @@ and linked dynamically or statically. To build it dynamically you will
 need the development libraries for the following packages installed (minimum
 versions are listed):
 
- - zlib-1.2.11
+ - zlib-1.2.13
  - bzip2-1.0.8
  - libffi-3.3
  - glib2-2.68.0

--- a/restraint.spec
+++ b/restraint.spec
@@ -23,7 +23,7 @@ Source0:	https://github.com/beaker-project/restraint/archive/%{name}-%{version}.
 # Sources for bundled, statically linked libraries
 Source101:      libffi-3.3.tar.gz
 Source102:      glib-2.68.0.tar.xz
-Source103:      zlib-1.2.12.tar.gz
+Source103:      zlib-1.2.13.tar.gz
 Source104:      bzip2-1.0.8.tar.gz
 Source105:      libxml2-2.9.10.tar.gz
 Source106:      curl-7.68.0.tar.bz2

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -1,5 +1,5 @@
 
-ZLIB = zlib-1.2.12
+ZLIB = zlib-1.2.13
 BZIP2 = bzip2-1.0.8
 LIBFFI = libffi-3.3
 GLIB = glib-2.68.0


### PR DESCRIPTION
Third party packages failing since zlib zlib-1.2.12 does not exist.