### PR TITLE
Fetch URI extract too many matched directories

### DIFF
--- a/releasenotes/notes/fix-fetch-f33da692d540ee7c.yaml
+++ b/releasenotes/notes/fix-fetch-f33da692d540ee7c.yaml
@@ -1,0 +1,17 @@
+fixes:
+  - |
+    Fix: Fetch URL extract too many matched directories
+    When `fetch` url is used, restraint is copying anything that
+    matches the pattern in `https://<snip>#pattern` regardless
+    of the location in the received path.  If pattern is `include`,
+    both `general/include, include` directories will match
+    when it should only be `include`.  Restraint will
+    now only select if it matches starting from beginning 
+    of received path NOT throughout directory path. But first,
+    the first `string/` must be ignored from the received
+    path since it is superfluous for the match since it
+    includes the repo and branch name added by curl.
+    Jobs that include this repo-branch prefix in the
+    fetch pattern will now fail with this changeset.
+    So fetching `https://<snip>#repo-branch/pattern`
+    will fail.

--- a/src/fetch_uri.c
+++ b/src/fetch_uri.c
@@ -163,6 +163,31 @@ archive_finish_callback (gpointer user_data)
     g_slice_free(FetchData, fetch_data);
     return FALSE;
 }
+static gboolean
+is_entry_prefixed_with_fragment(const gchar *entry_path,
+                                const gchar *fragment)
+{
+   
+    gchar *skip_entry_branch = NULL;
+   
+    if (fragment == NULL)
+        return FALSE;
+
+    skip_entry_branch = g_strstr_len(entry_path, -1, "/");
+    if (skip_entry_branch == NULL) {
+        return FALSE;
+    }
+    skip_entry_branch++;  // Skip '/'
+    if (fragment == NULL ||
+            (g_strstr_len(skip_entry_branch, strlen(fragment), fragment) != NULL &&
+            !(fragment[strlen(fragment)] != '/' && strlen(skip_entry_branch) ==
+                strlen(fragment) + 1))
+            ) {
+        return TRUE;
+    }
+
+    return FALSE;
+}
 
 static gboolean
 http_archive_read_callback (gpointer user_data)
@@ -192,10 +217,8 @@ http_archive_read_callback (gpointer user_data)
 
     const gchar *fragment = fetch_data->url->fragment;
     const gchar *entry_path = archive_entry_pathname(entry);
-    if (fragment == NULL || (g_strstr_len(entry_path, -1, fragment) != NULL &&
-            !(fragment[strlen(fragment)] != '/' && strlen(entry_path) ==
-                strlen(fragment) + 1))
-            ) {
+    if (fragment == NULL || is_entry_prefixed_with_fragment(entry_path, fragment))
+        {
         // Update pathname
         if (fragment != NULL) {
             newPath = g_build_filename(fetch_data->base_path,


### PR DESCRIPTION
When `fetch url` is used, restraint is copying anything that matches the pattern in `https://<snip>#pattern` regardless of the location in the received path.  If pattern is `include`, both `general/include, include` directories will match when it should only be `include`.  Restraint will now only select if it matches starting from beginning of received path NOT throughout directory path. But first, the first `string/` must be ignored from the received path since it is superfluous for the match since it includes the repo and branch name added by curl.
Jobs that include this repo-branch prefix in the fetch pattern will now fail with this changeset.
So fetching `https://<snip>#repo-branch/pattern` will fail.

Issue: 272