### PR TITLE
Remove reset of UEFI NextBoot for rstrnt-reboot

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -315,8 +315,10 @@ but does not actually trigger the reboot.
 If machine is UEFI and has efibootmgr installed, sets BootNext to
 BootCurrent and uses :envvar:`NEXTBOOT_VALID_TIME` to determine for
 how long (in seconds) this value is valid. After the specified time,
-BootOrder is reset to previous state. Default value for
-:envvar:`NEXTBOOT_VALID_TIME` is 180 seconds.
+BootNext setting is cleared so BootOrder takes precedence. Default
+value for :envvar:`NEXTBOOT_VALID_TIME` is 180 seconds. To prevent
+the clearing of BootNext, set :envvar:`NEXTBOOT_VALID_TIME` to
+0 seconds.
 
 Tasks can run this command before triggering a crash or rebooting
 through some other non-standard means. For example::

--- a/releasenotes/notes/fix-uefi-reboot-4552dec97663d4c9.yaml
+++ b/releasenotes/notes/fix-uefi-reboot-4552dec97663d4c9.yaml
@@ -1,0 +1,10 @@
+fixes:
+  - |
+    Fix: rstrnt-reboot not reliable for UEFI systems
+    When `efibootmgr` is present, the `NextBoot` variable is set to reboot
+    to `Current`.  When `rstrnt-prepare-reboot` was written, a timer was set
+    to remove `NextBoot` setting after 180 seconds. `rstrnt-reboot`
+    uses the `prepare` script and the timer wasn't long enough and not
+    needed for `rstrnt-reboot`. This changeset allows `NEXTBOOT_VALID_TIME`
+    to be set to 0.  When 0, the timer is not set and as a result
+    `NextBoot` will not be removed. `rstrnt-reboot` now uses a 0 timer.

--- a/scripts/rstrnt-prepare-reboot
+++ b/scripts/rstrnt-prepare-reboot
@@ -8,10 +8,6 @@
 PATH=/sbin:/usr/sbin:$PATH
 
 create_nextboot_timer() {
-        if [ -z "$NEXTBOOT_VALID_TIME" ] ; then
-                NEXTBOOT_VALID_TIME=180
-        fi
-
         # For future reference, it's possible to use `at` if supported everywhere
         nohup bash -c "
                 logger -s 'NextBoot value is valid for the next $NEXTBOOT_VALID_TIME seconds';
@@ -22,6 +18,14 @@ create_nextboot_timer() {
 }
 
 if efibootmgr &>/dev/null ; then
+    # if not defined
+    if [ -z "$NEXTBOOT_VALID_TIME" ] ; then
+            NEXTBOOT_VALID_TIME=180
+    # elif not a valid number
+    elif [[ $NEXTBOOT_VALID_TIME =~ [^0-9] ]]; then
+            logger -s "NEXTBOOT_VALID_TIME not numeric. Changing to default of 180"
+            NEXTBOOT_VALID_TIME=180
+    fi
     os_boot_entry=$(efibootmgr | awk '/BootCurrent/ { print $2 }')
     # fall back to /root/EFI_BOOT_ENTRY.TXT if it exists and BootCurrent is not available
     if [[ -z "$os_boot_entry" && -f /root/EFI_BOOT_ENTRY.TXT ]] ; then
@@ -30,10 +34,15 @@ if efibootmgr &>/dev/null ; then
     if [[ -n "$os_boot_entry" ]] ; then
         logger -s "efibootmgr -n $os_boot_entry"
         efibootmgr -n $os_boot_entry
-        create_nextboot_timer
-        # Adjust watchdog if running inside of test case
-        if [[ -n $RSTRNT_RECIPE_URL && $RSTRNT_MAXTIME ]] ; then
-            rstrnt-adjust-watchdog $(($RSTRNT_MAXTIME + $NEXTBOOT_VALID_TIME))
+        if [[ $NEXTBOOT_VALID_TIME > 0 ]]; then
+            create_nextboot_timer
+            # Adjust watchdog if running inside of test case
+            if [[ -n $RSTRNT_RECIPE_URL && $RSTRNT_MAXTIME ]] ; then
+                rstrnt-adjust-watchdog $(($RSTRNT_MAXTIME + $NEXTBOOT_VALID_TIME))
+            fi
+        else
+            logger -s "NEXTBOOT_VALID_TIME is zero. BootNext setting will persist."
+            sleep 5
         fi
     else
         logger -s "Could not determine value for BootNext!"

--- a/scripts/rstrnt-reboot
+++ b/scripts/rstrnt-reboot
@@ -12,7 +12,7 @@ trap "" SIGTERM
 
 PATH=/sbin:/usr/sbin:$PATH
 
-/usr/bin/rstrnt-prepare-reboot
+NEXTBOOT_VALID_TIME=0 /usr/bin/rstrnt-prepare-reboot
 shutdown -r now
 
 # Wait for the shutdown to kill us.  Sleep to avoid returning


### PR DESCRIPTION
When rstrnt-reboot is executed, it should set BootNext to current boot and NOT remove BootNext after a period of time like what is done in rstrnt-prepare-reboot.  rstrnt-reboot uses rstrnt-prepare-reboot so both have been modified to handle timer of zero which disables the reset of BootNext configuration.