### PR TITLE
Improve FAILURESTRINGS to match words accurately

### DIFF
--- a/plugins/report_result.d/01_dmesg_check
+++ b/plugins/report_result.d/01_dmesg_check
@@ -34,7 +34,7 @@ FAILUREFILENM=${FAILUREFILENM:-"/usr/share/rhts/failurestrings"}
 if [ ! -s "${FAILUREFILENM}" ]; then
     if [ -z "${FAILURESTRINGS}" ]; then
         DMESG_FAIL_SELECTOR="Default FAILURESTRINGS"
-        FAILURESTRINGS="Oops|BUG|NMI appears to be stuck|Badness at"
+        FAILURESTRINGS="\bOops\b|\bBUG\b|NMI appears to be stuck|Badness at"
     else
         DMESG_FAIL_SELECTOR="FAILURESTRINGS Environment Variable"
     fi

--- a/plugins/tests/test_dmesg_check.py
+++ b/plugins/tests/test_dmesg_check.py
@@ -80,7 +80,7 @@ NMI appears to be stuck
 DMESG Selectors:
 Used Default FAILURESTRINGS and Default FALSESTRINGS
 ====================================================
-FAILURESTRINGS: Oops|BUG|NMI appears to be stuck|Badness at
+FAILURESTRINGS: \bOops\b|\bBUG\b|NMI appears to be stuck|Badness at
 FailureStrings file not found.
 ====================================================
 FALSESTRINGS: BIOS BUG|DEBUG|mapping multiple BARs.*IBM System X3250 M4


### PR DESCRIPTION
Fixes: #273 

Currently regex 'Oops|BUG|NMI appears to be stuck|Badness at' is used by FAILURESTRINGS, which can match word 'DEBUG' because word 'BUG' is part of it. Hence, we should improve the regex to avoid such kind of wrong match.

