### PR TITLE
Back out the default 'main' branch change

### DIFF
--- a/src/fetch_git.c
+++ b/src/fetch_git.c
@@ -30,8 +30,6 @@
 #include "fetch.h"
 #include "fetch_git.h"
 
-static const gchar *g_git_branches[] = {GIT_BRANCHES};
-
 static gint
 packet_length(const gchar *linelen)
 {
@@ -232,16 +230,9 @@ myopen(FetchData *fetch_data, GError **error)
                 "While writing to %s: ", fetch_data->url->host);
         goto error;
     }
-
-    // traverse git branches one by one
-    for (gint i = 0; i < sizeof (g_git_branches) / sizeof (const gchar *); i++) {
-        gchar *branch = (gchar *)(g_git_branches[i]);
-        write_succeeded = packet_write(fetch_data->ostream, &tmp_error, "argument %s:%s\0",
-                               fetch_data->url->query == NULL ? branch: fetch_data->url->query,
-                               fetch_data->url->fragment == NULL ? "" : fetch_data->url->fragment + fragment_offset);
-        if (write_succeeded)
-            break;
-    }
+    write_succeeded = packet_write(fetch_data->ostream, &tmp_error, "argument %s:%s\0",
+                           fetch_data->url->query == NULL ? GIT_BRANCH : fetch_data->url->query,
+                           fetch_data->url->fragment == NULL ? "" : fetch_data->url->fragment + fragment_offset);
     if (!write_succeeded) {
         g_propagate_prefixed_error(error, tmp_error,
                 "While writing to %s: ", fetch_data->url->host);

--- a/src/fetch_git.h
+++ b/src/fetch_git.h
@@ -18,13 +18,8 @@
 #ifndef _RESTRAINT_FETCH_GIT_H
 #define _RESTRAINT_FETCH_GIT_H
 
-/*
- * The main branch ("main") is fetched by default, but we also support to
- * fetch the legacy one (i.e. "master") because it is required by some old
- * repositories.
- */
-#define GIT_BRANCHES "main", "master"
 #define GIT_PORT 9418
+#define GIT_BRANCH "master"
 #define HDR_LEN_SIZE 4
 
 #include <libsoup/soup.h>


### PR DESCRIPTION
The fix of https://github.com/restraint-harness/restraint/pull/279 was incomplete, which introduce a new failure that user has to specify the url like:
```xml
<fetch url="git://gerrit-git.engineering.redhat.com/kernel-tests?master#virt/beaker-core-task/install"/>
```
if the default branch of a repo is not 'main' but 'master'.  Hence, let's back out the related change.

