### PR TITLE
Fixes for broken builds

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -306,7 +306,7 @@ process_run (const gchar *command,
 
         // Print the command being executed.
         gchar *pcommand = g_strjoinv (" ", (gchar **) process_data->command);
-        g_print ("use_pty:%s %s\n", use_pty ? "TRUE" : "FALSE", pcommand);
+        printf ("use_pty:%s %s\n", use_pty ? "TRUE" : "FALSE", pcommand);
         g_free (pcommand);
 
         /* Spawn the command */

--- a/src/xml.c
+++ b/src/xml.c
@@ -51,7 +51,7 @@ restraint_xml_read_callback(GObject *source, GAsyncResult *result, gpointer user
         xmlParserErrors xmlresult = xmlParseChunk(ctxt->parser_ctxt, ctxt->buf, size,
                 size > 0 ? 0 : 1);
         if (xmlresult != XML_ERR_OK) {
-            xmlError *xmlerr = xmlCtxtGetLastError(ctxt->parser_ctxt);
+            const xmlError *xmlerr = xmlCtxtGetLastError(ctxt->parser_ctxt);
             g_set_error_literal(&ctxt->error, RESTRAINT_XML_PARSE_ERROR,
                     RESTRAINT_XML_PARSE_ERROR_BAD_SYNTAX,
                     xmlerr != NULL ? xmlerr->message : "Unknown libxml error");

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -169,7 +169,7 @@ $(GLIB).tar.xz:
 
 TAR_BALLS += $(ZLIB).tar.gz
 $(ZLIB).tar.gz:
-	curl -f -L -O http://zlib.net/$@
+	curl -f -L -O https://zlib.net/fossils/$@
 
 TAR_BALLS += $(BZIP2).tar.gz
 $(BZIP2).tar.gz:


### PR DESCRIPTION
At this moment the restraint builds with third-party libraries is broken due to a broken URL to pull zlib tarball. 

You can verify this patch by running the following commands in third-party directory.

```
$ make clean-tarballs
rm -rf libffi-3.3.tar.gz glib-2.68.0.tar.xz zlib-1.2.13.tar.gz bzip2-1.0.8.tar.gz libxml2-2.9.10.tar.gz curl-7.68.0.tar.bz2 libarchive-3.4.0.tar.gz xz-5.2.4.tar.gz sqlite-autoconf-3310100.tar.gz intltool-0.51.0.tar.gz libsoup-2.52.2.tar.xz autoconf-2.69.tar.gz json-c-0.13.1.tar.gz openssl-1.1.1k.tar.gz m4-1.4.19.tar.xz

$ make tarballs
...
```