### PR TITLE
Add multi machine CI infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ install:
 check:
 	set -e; for i in $(SUBDIRS); do $(MAKE) -C $$i check; done
 
+.PHONY: check-daemon
+check-daemon:
+	set -e; $(MAKE) -C tests/daemon check-daemon-container
+
 .PHONY: valgrind
 valgrind:
 	set -e; $(MAKE) -C src valgrind

--- a/containers/testclient.sh
+++ b/containers/testclient.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# script: bootstrap.sh
+
+readonly RUN_SHELL=/bin/bash
+
+if [ "$1" = "-r" ] ; then
+	"$RUN_SHELL" "$2"
+	shift 2
+fi
+
+dnf install -y openssh-clients libxslt psmisc nginx
+cp ./keys/testkey /root/.ssh/id_rsa
+cp ./keys/testkey.pub /root/.ssh/id_rsa.pub
+
+#setup webserver
+echo "server { root /restraint/tests/daemon/www/html; }" > /etc/nginx/conf.d/tc.conf
+
+cmd=$*
+
+exec ${cmd:-${RUN_SHELL}}

--- a/containers/testmachine.sh
+++ b/containers/testmachine.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# script: bootstrap.sh
+
+readonly RUN_SHELL=/bin/bash
+
+if [ "$1" = "-r" ] ; then
+	"$RUN_SHELL" "$2"
+	shift 2
+fi
+
+dnf install -y openssh-server psmisc
+ssh-keygen -A
+cat ./keys/*.pub >> /root/.ssh/authorized_keys
+
+cmd=$*
+
+exec ${cmd:-${RUN_SHELL}}

--- a/tests/daemon/Makefile
+++ b/tests/daemon/Makefile
@@ -1,0 +1,60 @@
+SHELL = /bin/bash
+
+SSH_KEY := testkey
+
+.PHONY: check-keys-setup
+check-keys-setup:
+	@mkdir -p ../../keys; \
+	pushd ../../keys; \
+	if ! test -f $(SSH_KEY).pub; then \
+		ssh-keygen -f $(SSH_KEY) -t rsa -q -N ""; \
+	fi; \
+	popd
+
+.PHONY: check-daemon-setup-testmachine
+check-daemon-setup-testmachine:
+	@echo "SETTING UP TESTMACHINE in restraint-testmachine git-worktree"
+	@echo "============================================================"
+	@git worktree add -d ../../../restraint-testmachine 2>/dev/null || \
+		echo "Worktree already exists, not copying changes over"; \
+	pushd ../../../restraint-testmachine > /dev/null ; \
+	if ! test -f ./keys/$(SSH_KEY).pub; then \
+		mkdir -p keys; \
+		cp ../restraint/keys/$(SSH_KEY).pub ./keys/; \
+	fi; \
+	if ! podman container exists "restraint-checks-tm-fedora-latest"; then \
+		./containers/run.sh -e /restraint/containers/testmachine.sh -c tm make install; \
+	fi; \
+	./containers/run.sh -c tm /usr/sbin/sshd -D &
+	# let container start to avoid race with testclient
+	sleep 1
+
+
+.PHONY: check-daemon-setup-testclient
+check-daemon-setup-testclient:
+	@pushd ../../ > /dev/null ; \
+	if ! podman container exists "restraint-checks-tc-fedora-latest"; then \
+		./containers/run.sh -e /restraint/containers/testclient.sh -c tc make install; \
+	fi; \
+	./containers/run.sh -c tc make -C tests/daemon check-daemon; \
+	popd
+
+.PHONY: check-daemon-container
+check-daemon-container: check-keys-setup check-daemon-setup-testmachine check-daemon-setup-testclient stop-container
+
+.PHONY: check-daemon
+check-daemon:
+	# private container network, should be no MITM vulnerabilities
+	ssh -o StrictHostKeyChecking=no restraint-checks-tm-fedora-latest echo "HELLO from TESTMACHINE!!!"
+	restraint -t restraint-checks-tm-fedora-latest -j test.xml
+
+.PHONY: stop-container
+stop-container:
+	# stop the testmachine by killing the sshd
+	@podman exec -ti restraint-checks-tm-fedora-latest killall sshd
+	@echo "Waiting for testmachine to stop"
+
+.PHONY: clean-container
+clean-container:
+	podman rm restraint-checks-tc-fedora-latest
+	podman rm restraint-checks-tm-fedora-latest

--- a/tests/daemon/README.rst
+++ b/tests/daemon/README.rst
@@ -1,0 +1,35 @@
+========================
+Restraint Daemon Testing
+========================
+
+This area is designed to allow using containers to test the restraint client
+on containerA to run tests on the restraint daemon on containerB using a
+private container network bridge.
+
+The goal is to make duplicating a user's workflow easy by just utilizing an
+xml they have provided or using the default inside this directory.  Having a
+collection of user workflows will make it easier to make changes to
+restraint and test for regressions across a variety of workflows safely.  It
+should also make it easier to duplicate and debug new workflow issues
+locally.
+
+The main logic is
+
+
+  ContainerA                     ContainerB
+  TestMachine                    TestClient
+
+  sshd           <-------        ssh / restraint
+  restraintd       ----->        git repo
+
+
+
+Underneath the hood
+
+To avoid sharing code, create a git worktree to the TestMachine that copies
+over the restraint code to be built/installed in the container.
+
+Create ssh keys and share them between the containers to automate the
+communication.
+
+Run the requested job xml on the test machine.

--- a/tests/daemon/test.xml
+++ b/tests/daemon/test.xml
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='utf-8'?>
+<job>
+  <recipeSet>
+    <!-- host type: bare_metal -->
+    <recipe ks_meta="redhat_ca_cert harness='restraint-rhts beakerlib' selinux=--permissive" kernel_options="" kernel_options_post="rd.emergency=reboot kunit.enable=1 efi=runtime">
+      <task name="/test/misc/machineinfo">
+        <fetch url="https://gitlab.com/redhat/centos-stream/tests/kernel/kernel-tests/-/archive/production/kernel-tests-production.zip#test/misc/machineinfo"/>
+        <params>
+          <param name="CKI_ID" value="3"/>
+          <param name="CKI_IS_TEST" value="True"/>
+          <param name="CKI_NAME" value="machineinfo"/>
+          <param name="CKI_UNIVERSAL_ID" value="machineinfo"/>
+          <param name="CKI_WAIVED" value="True"/>
+        </params>
+      </task>
+      <task name="/test/misc/machineinfo">
+        <fetch url="https://gitlab.com/redhat/centos-stream/tests/kernel/kernel-tests/-/archive/production/kernel-tests-production.zip#test/misc/machineinfo"/>
+        <params>
+          <param name="CKI_ID" value="3"/>
+          <param name="CKI_IS_TEST" value="True"/>
+          <param name="CKI_NAME" value="machineinfo"/>
+          <param name="CKI_UNIVERSAL_ID" value="machineinfo"/>
+          <param name="CKI_WAIVED" value="True"/>
+        </params>
+      </task>
+      <task name="/test/misc/machineinfo">
+        <fetch url="https://gitlab.com/redhat/centos-stream/tests/kernel/kernel-tests/-/archive/production/kernel-tests-production.zip#test/misc/machineinfo"/>
+        <params>
+          <param name="CKI_ID" value="3"/>
+          <param name="CKI_IS_TEST" value="True"/>
+          <param name="CKI_NAME" value="machineinfo"/>
+          <param name="CKI_UNIVERSAL_ID" value="machineinfo"/>
+          <param name="CKI_WAIVED" value="True"/>
+        </params>
+      </task>
+      <task name="/test/misc/machineinfo">
+        <fetch url="https://gitlab.com/redhat/centos-stream/tests/kernel/kernel-tests/-/archive/production/kernel-tests-production.zip#test/misc/machineinfo"/>
+        <params>
+          <param name="CKI_ID" value="3"/>
+          <param name="CKI_IS_TEST" value="True"/>
+          <param name="CKI_NAME" value="machineinfo"/>
+          <param name="CKI_UNIVERSAL_ID" value="machineinfo"/>
+          <param name="CKI_WAIVED" value="True"/>
+        </params>
+      </task>
+    </recipe>
+  </recipeSet>
+</job>


### PR DESCRIPTION
Add infrastructure to allow testing of the restraint client and daemon across two containers networked together.

Most of the changes are to support the initial bring up of two containers and allow them to communicate over ssh.  There is a single job xml to verify the infrastructure is working correctly.

Initial work is for two local containers to run.  Followon work will support running in GitHub CI.