### PR TITLE
Suppress ReallocZero for libproxy/duktape

### DIFF
--- a/tests/valgrind.supp
+++ b/tests/valgrind.supp
@@ -694,3 +694,15 @@
    fun:_dlerror_run
    ...
 }
+
+{
+   libproxy/duktape/realloc
+   Memcheck:ReallocZero
+   fun:realloc
+   ...
+   fun:duk_compile_raw
+   fun:duk_eval_raw
+   ...
+   fun:px_manager_new_with_options
+   fun:px_proxy_factory_new
+}


### PR DESCRIPTION
Suppressed Valgrind realloc size zero errors from duktape library used by libproxy since version 0.5.

Closes #310