### PR TITLE
Release Notes 0.4.5

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,6 +1,25 @@
 Release Notes
 =============
 
+Restraint 0.4.5
+---------------
+
+Bug Fixes
+~~~~~~~~~
+
+* | Improve task fetch for git repositories
+  | To improve reliability when fetching tasks from git repositories, the number of retries has been changed from 3 to 30.
+    To further increase the chance of success, the fetch interval has been changed from 10 seconds to 20 seconds.
+
+Other Notable Changes
+~~~~~~~~~~~~~~~~~~~~~
+
+* | Dependency Updates
+  | The following dependencies have been updated:
+
+    * openssl: 1.1.1k -> 1.1.1w
+    * json-c: 0.13.1 -> 0.16
+
 Restraint 0.4.4
 ---------------
 

--- a/releasenotes/notes/dependency-upgrade-openssl-json-c-245cf07aeb019a3f.yaml
+++ b/releasenotes/notes/dependency-upgrade-openssl-json-c-245cf07aeb019a3f.yaml
@@ -1,0 +1,6 @@
+other:
+  - |
+    Dependency Updates
+    The following dependencies have been updated:
+    - openssl: 1.1.1k -> 1.1.1w
+    - json-c: 0.13.1 -> 0.16

--- a/releasenotes/notes/extend-task-fetch-retries-b2295a6d7a82576f.yaml
+++ b/releasenotes/notes/extend-task-fetch-retries-b2295a6d7a82576f.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Improve task fetch for git repositories 
+    To improve reliability when fetching tasks from git repositories, the number of retries has been changed from 3 to 30. 
+    To further increase the chance of success, the fetch interval has been changed from 10 seconds to 20 seconds.


### PR DESCRIPTION
The release notes contain all the major changes we made between 0.4.4 and 0.4.5. 

All other changes are related to the development environment or ensuring we can compile Restraint again.


This is the complete commit log

```
34cae42 Release Notes for Restraint version 0.4.5
cb70ae7 Add note for dependency updates
32902d2 Add note for extend task fetch
3f6a0e3 Update GH Actions to use Quay CR
811bce3 Use aliases to cover latest build roots
d5d7b8a Bump third-party json-c to 0.16
3e4eef4 Declare build_type_safety_c for Fedora 40
c299c44 Bump third-party OpenSSL to 1.1.1w
179b2df Suppress ReallocZero for libproxy/duktape
055a0a9 Add CentOS Stream static builds in review checks
af33aa7 Use pcre-static for CentOS static builds
e9fb8ae Add CentOS Stream container provision scripts
71ba7ab Use printf instead of g_print to avoid additional formatting
d3acd02 Use const qualifier
32a1bdf Change URL to pull zlib tarball
e5645a0 Extend task_fetch retries
41bdbee Enable Fedora39 in checks, COPR Builds, container scripts
3c58119 Drop Fedora37/Add Fedora40 to release file
73ad3be Drop Fedora36/Add Fedora39 to release file
4a20ada Enable Fedora38 in checks, COPR Builds, container scripts
```

🚀 

Signed-off-by: Martin Styk <mart.styk@gmail.com>