### PR TITLE
Add support for rhel-10 and centos-stream-10

### DIFF
--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -138,10 +138,6 @@ jobs:
       - name: Install deps
         run: |
           yum install -y ${{ env.DNF_COMMAND }} 'dnf-command(builddep)' tito
-      - name: Enable PowerTools
-        run: |
-          yum config-manager --set-enabled powertools
-        if: contains(matrix.version, '8')
       - name: Enable CRB
         run: |
           yum config-manager --set-enabled crb

--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -1,3 +1,3 @@
 [dist-git]
 releaser = tito.release.DistGitReleaser
-branches = beaker-harness-rhel-7 beaker-harness-rhel-8 beaker-harness-rhel-9 eng-fedora-38 eng-fedora-39 eng-fedora-40
+branches = beaker-harness-rhel-7 beaker-harness-rhel-8 beaker-harness-rhel-9 beaker-harness-rhel-10 eng-fedora-40 eng-fedora-41 eng-fedora-42

--- a/restraint.spec
+++ b/restraint.spec
@@ -9,8 +9,10 @@
 %global with_selinux_policy 0
 %endif
 
-%if 0%{?with_static:1} && 0%{?fedora} >= 40
+%if 0%{?with_static:1}
+%if 0%{?fedora} >= 40 || 0%{?rhel} >= 10
 %global build_type_safety_c 2
+%endif
 %endif
 
 Name:		restraint
@@ -115,7 +117,7 @@ BuildRequires:  tar
 %{?with_static:BuildRequires: cmake}
 # libselinux Requires.private
 %{?with_static:BuildRequires: libsepol-static}
-%if 0%{?rhel} < 8 || 0%{?centos}
+%if 0%{?rhel} < 8 || 0%{?centos} < 10
 %{?with_static:BuildRequires: pcre-static}
 %else
 %{?with_static:BuildRequires: pcre2-static}

--- a/third-party/Makefile
+++ b/third-party/Makefile
@@ -248,6 +248,7 @@ $(INTLTOOL)/.patches-done: $(INTLTOOL)
 $(LIBSOUP)/.patches-done: $(LIBSOUP)
 	patch -d$(LIBSOUP) -p1 <libsoup-no-pkgconfig-version-check.patch
 	patch -d$(LIBSOUP) -p1 <libsoup-perl580.patch
+	patch -d$(LIBSOUP) -p1 <libsoup-gcc15-incompatible-pointers.patch
 	sed -i -e "/^#!/c\#!$(PYTHON)" $(LIBSOUP)/libsoup/tld-parser.py
 	touch $@
 

--- a/third-party/libsoup-gcc15-incompatible-pointers.patch
+++ b/third-party/libsoup-gcc15-incompatible-pointers.patch
@@ -1,0 +1,41 @@
+From 555466d397d24505a6bbfa2bd8da41e47cc8e436 Mon Sep 17 00:00:00 2001
+From: Claudio Saavedra <csaavedra@igalia.com>
+Date: Mon, 11 Dec 2017 14:39:47 +0200
+Subject: [PATCH] gobject: explicitly cast on g_object_ref/unref() calls
+
+GObject now issues warnings for implicit casts on these being
+called. See https://bugzilla.gnome.org/show_bug.cgi?id=790697.
+---
+ libsoup/soup-address.c         | 2 +-
+ libsoup/soup-content-sniffer.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libsoup/soup-address.c b/libsoup/soup-address.c
+index 650cf8152..0351db504 100644
+--- a/libsoup/soup-address.c
++++ b/libsoup/soup-address.c
+@@ -1246,7 +1246,7 @@ soup_address_connectable_enumerate (GSocketConnectable *connectable)
+ 	SoupAddressPrivate *priv;
+ 
+ 	addr_enum = g_object_new (SOUP_TYPE_ADDRESS_ADDRESS_ENUMERATOR, NULL);
+-	addr_enum->addr = g_object_ref (connectable);
++	addr_enum->addr = g_object_ref (SOUP_ADDRESS (connectable));
+ 
+ 	priv = soup_address_get_instance_private (addr_enum->addr);
+ 	addr_enum->orig_offset = priv->offset;
+diff --git a/libsoup/soup-content-sniffer.c b/libsoup/soup-content-sniffer.c
+index 8b4b80524..7573fde57 100644
+--- a/libsoup/soup-content-sniffer.c
++++ b/libsoup/soup-content-sniffer.c
+@@ -854,7 +854,7 @@ soup_content_sniffer_request_queued (SoupSessionFeature *feature,
+ {
+ 	SoupMessagePrivate *priv = SOUP_MESSAGE_GET_PRIVATE (msg);
+ 
+-	priv->sniffer = g_object_ref (feature);
++	priv->sniffer = g_object_ref (SOUP_CONTENT_SNIFFER (feature));
+ 	g_signal_connect (msg, "got-headers",
+ 			  G_CALLBACK (soup_content_sniffer_got_headers_cb),
+ 			  feature);
+-- 
+GitLab
+


### PR DESCRIPTION
This patch fixes two build issues with CentOS-Stream 10.  The first is
using pcre2-static instead of pcre-static.  The second is to handle a
ppc failure that seems related to the build_type_safety_check_c put in
for Fedora > 40.  RHEL-10 is inheriting the same problem.
