### PR TITLE
Changes to support ostree bootable containers

### DIFF
--- a/init.d/restraintd.service
+++ b/init.d/restraintd.service
@@ -8,6 +8,7 @@ Type=simple
 StandardError=journal+console
 ExecStartPre=/usr/bin/check_beaker
 ExecStart=/usr/bin/restraintd --port 8081
+StateDirectory=restraint
 KillMode=process
 OOMScoreAdjust=-1000
 OOMPolicy=continue

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -10,7 +10,7 @@ clean:
 .PHONY: install
 install:
 	set -e; for i in $(SUBDIRS); do $(MAKE) -C $$i install; done
-	install -m 644 data/install_config $(DESTDIR)/var/lib/restraint/
+	install -m 644 -D data/install_config $(DESTDIR)/etc/restraint/install_config
 
 .PHONY: check
 check:

--- a/plugins/pkg_commands.d/centos
+++ b/plugins/pkg_commands.d/centos
@@ -8,6 +8,6 @@ if [ -f "/run/ostree-booted" ];then
     RSTRNT_PKG_ARGS=${RSTRNT_PKG_ARGS:--y --idempotent --allow-inactive}
     RSTRNT_PKG_INSTALL=${RSTRNT_PKG_INSTALL:-install --apply-live}
 elif [ 0"$(echo $VERSION_ID | cut -d'.' -f1)" -ge 8 ]; then
-    # RHEL 8 and newer use dnf as default
+    # CentOS 8 and newer use dnf as default
     RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-dnf}
 fi

--- a/plugins/pkg_commands.d/fedora
+++ b/plugins/pkg_commands.d/fedora
@@ -2,7 +2,12 @@
 
 . /etc/os-release
 
-# Fedora 22 and newer use dnf as default
-if [ 0"$VERSION_ID" -gt 21 ]; then
+if [ -f "/run/ostree-booted" ]; then
+    # OSTree based filesystems are read-only and install with rpm-ostree
+    RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-rpm-ostree}
+    RSTRNT_PKG_ARGS=${RSTRNT_PKG_ARGS:--y --idempotent --allow-inactive}
+    RSTRNT_PKG_INSTALL=${RSTRNT_PKG_INSTALL:-install --apply-live}
+elif [ 0"$VERSION_ID" -gt 21 ]; then
+    # Fedora 22 and newer use dnf as default
     RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-dnf}
 fi

--- a/restraint.conf
+++ b/restraint.conf
@@ -1,0 +1,3 @@
+# Type Path Mode User Group Age Argument
+d /mnt/scratchspace 0777 root root -
+d /mnt/testarea 1777 root root -

--- a/restraint.spec
+++ b/restraint.spec
@@ -249,6 +249,12 @@ fi
 popd
 %endif
 
+%if %{with_systemd}
+mkdir -p $RPM_BUILD_ROOT/%{_tmpfilesdir}
+install -m 0644 %{name}.conf $RPM_BUILD_ROOT/%{_tmpfilesdir}/%{name}.conf
+%endif
+
+
 %post
 if [ "$1" -le "1" ] ; then # First install
 %if %{with_systemd}
@@ -343,7 +349,12 @@ fi
 %{_datadir}/selinux/packages/%{name}/restraint.pp
 %endif
 
+%if %{with_systemd}
+# Don't package, systemd will create this on first instance
+%exclude /var/lib/%{name}
+%else
 %dir /var/lib/%{name}
+%endif
 
 %files client
 %attr(0755, root, root)%{_bindir}/%{name}
@@ -362,7 +373,8 @@ fi
 %attr(0755, root, root)%{_bindir}/rhts-lint
 %attr(0755, root, root)%{_bindir}/rhts-report-result
 %attr(0755, root, root)%{_bindir}/rhts-flush
-%config(noreplace)/var/lib/%{name}/install_config
+%dir %{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/install_config
 
 # Symlinks do not have attributes
 %{_bindir}/rhts-sync-set
@@ -381,8 +393,12 @@ fi
 %{_bindir}/rhts_recipe_sync_block
 %{_bindir}/rhts-abort
 %{_datadir}/rhts/lib/rhts-make.include
+%if %{with_systemd}
+%config %{_tmpfilesdir}/%{name}.conf
+%else
 /mnt/scratchspace
 %attr(1777,root,root)/mnt/testarea
+%endif
 %if 0%{?rhel}%{?fedora} > 4
 %{_datadir}/selinux/packages/%{name}/rhts.pp
 %endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -24,7 +24,7 @@
 #define CMD_ENV_DIR "/var/lib/restraint"
 #define CMD_ENV_FILE_FORMAT "%s/rstrnt-commands-env-%u.sh"
 
-#define INSTALL_CONFIG_FILE "/var/lib/restraint/install_config"
+#define INSTALL_CONFIG_FILE "/etc/restraint/install_config"
 #define INSTALL_DIR_VAR "INSTALL_DIR"
 #define INSTALL_DIR_DEFAULT "/var/lib/restraint/tests"
 


### PR DESCRIPTION
Ostree has bootable containers with a read-only filesystem.  This filesystem doesn't support dnf install nor current restraint directory layout and needs a few tweaks.  With these changes, restraint should work out of the box with bootable containers over ssh.  

Signed-off-by: Don Zickus <dzickus@redhat.com>