### PR TITLE
Support rpm-ostree package installation

### DIFF
--- a/plugins/pkg_commands.d/rhel
+++ b/plugins/pkg_commands.d/rhel
@@ -3,6 +3,10 @@
 . /etc/os-release
 
 # RHEL 8 and newer use dnf as default
-if [ 0"$(echo $VERSION_ID | cut -d'.' -f1)" -ge 8 ]; then
+if stat /run/ostree-booted > /dev/null 2>&1; then
+    RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-rpm-ostree}
+    RSTRNT_PKG_ARGS=${RSTRNT_PKG_ARGS:-"--idempotent --allow-inactive"}
+    RSTRNT_PKG_INSTALL=${RSTRNT_PKG_INSTALL:-"install --apply-live"}
+elif [ 0"$(echo $VERSION_ID | cut -d'.' -f1)" -ge 8 ]; then
     RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-dnf}
 fi


### PR DESCRIPTION
Support rpm-ostree package when using restraint in bootc image 