### PR TITLE
Package /etc/restraint correctly

### DIFF
--- a/restraint.spec
+++ b/restraint.spec
@@ -357,6 +357,7 @@ fi
 %else
 %dir /var/lib/%{name}
 %endif
+%dir %{_sysconfdir}/%{name}
 
 %files client
 %attr(0755, root, root)%{_bindir}/%{name}
@@ -375,7 +376,6 @@ fi
 %attr(0755, root, root)%{_bindir}/rhts-lint
 %attr(0755, root, root)%{_bindir}/rhts-report-result
 %attr(0755, root, root)%{_bindir}/rhts-flush
-%dir %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/install_config
 
 # Symlinks do not have attributes

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -11,5 +11,9 @@ install:
 	mkdir -p $(DESTDIR)/usr/bin
 	for file in $(FILES); do install -m 755 $$file $(DESTDIR)/usr/bin; done
 
+	#The check_beaker script when executed, outputs a config file to
+        #/etc/restraint. Create the directory for packaging purposes.
+	mkdir -p $(DESTDIR)/etc/restraint
+
 .PHONY: check
 check:

--- a/specfiles/restraint-upstream.spec
+++ b/specfiles/restraint-upstream.spec
@@ -116,6 +116,7 @@ fi
 /usr/share/%{name}/plugins/task_run.d
 /usr/share/%{name}/pkg_commands.d
 /var/lib/%{name}
+%{_sysconfdir}/%{name}
 %{_datadir}/selinux/packages/%{name}/restraint.pp
 
 %files client


### PR DESCRIPTION
With the previous commit b3bffb90d46a5, the need for /etc/restraint is not just limited to restraint-rhts it is also required by the main restraint package.  Let's reflect that change in the spec file.

Otherwise check-beaker fails to write to /etc/restraint/config.conf because the directory /etc/restraint doesn't exist.