### PR TITLE
scripts/rstrnt-package: fix rpm-ostree pkgs install

### DIFF
--- a/scripts/rstrnt-package
+++ b/scripts/rstrnt-package
@@ -64,18 +64,18 @@ _pkg_cmd() {
 }
 
 if [ "$operation" = "install" ]; then
-    _pkg_cmd $pkg_install
+    _pkg_cmd "$pkg_install"
     RC=$?
     if [[ $RC == 0 && $pkg_cmd == "yum" ]]; then
        rpm -q --whatprovides $package
        RC=$?
     fi
 elif [ "$operation" = "remove" ]; then
-    _pkg_cmd $pkg_remove
+    _pkg_cmd "$pkg_remove"
     RC=$?
 elif [ "$operation" = "reinstall" ]; then
-    _pkg_cmd $pkg_remove
-    _pkg_cmd $pkg_install
+    _pkg_cmd "$pkg_remove"
+    _pkg_cmd "$pkg_install"
     RC=$?
     if [[ $RC == 0 && $pkg_cmd == "yum" ]]; then
        rpm -q --whatprovides $package


### PR DESCRIPTION
w/o this fix, the parameter --apply-live won't be applied when do rstrnt-package install.