### PR TITLE
Fix systemd control of /var/lib/restraint to legacy service

### DIFF
--- a/init.d/restraintd.service-legacy
+++ b/init.d/restraintd.service-legacy
@@ -8,6 +8,7 @@ Type=simple
 StandardError=syslog+console
 ExecStartPre=/usr/bin/check_beaker
 ExecStart=/usr/bin/restraintd --port 8081
+StateDirectory=restraint
 KillMode=process
 OOMScoreAdjust=-1000
 


### PR DESCRIPTION
Older releases like RHEL-8 and RHEL-7 use the restraintd.service-legacy file which did not get the 'StateDirectory=restraint' option added. This caused the /var/lib/restraint not to be created and various rstrnt scripts that wrote to that directory to not work.  Easy fix.