### PR TITLE
restraint-rhts-set should use /etc/restraint to record anything

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -567,7 +567,7 @@ server listens for events received on `TCP port 6776`.  All subsequent `set`
 and `block` operations are forwarded to the `rstrnt-sync` server by way of
 this socket.
 
-This script also writes the states to the file named `/var/lib/restraint/rstrnt_events`.
+This script also writes the states to the file named `/etc/restraint/rstrnt_events`.
 This file is used when the system reboots enabling the states to be restored.
 
 .. _restraint_client:

--- a/plugins/task_run.d/30_restore_events
+++ b/plugins/task_run.d/30_restore_events
@@ -7,8 +7,8 @@ rstrnt_info "*** Running Plugin: $0"
 # Don't run from PLUGINS
 if [ -z "$RSTRNT_NOPLUGINS" ]; then
     # If we rebooted we need to re-post all the previous events
-    if [ -e "/var/lib/restraint/rstrnt_events" ]; then
-        for event in $(cat /var/lib/restraint/rstrnt_events); do
+    if [ -e "/etc/restraint/rstrnt_events" ]; then
+        for event in $(cat /etc/restraint/rstrnt_events); do
             rstrnt_info "event $event "$(rstrnt-sync set $event)
         done
     fi

--- a/scripts/rstrnt-sync-set
+++ b/scripts/rstrnt-sync-set
@@ -72,4 +72,4 @@ echo "$command -- State set = ${XTRA}_${state}"
 
 rstrnt-sync set ${XTRA}_${state}
 # Record the event in case any tests reboot the system
-echo "${XTRA}_${state}" >> /var/lib/restraint/rstrnt_events
+echo "${XTRA}_${state}" >> /etc/restraint/rstrnt_events

--- a/src/fetch_uri.c
+++ b/src/fetch_uri.c
@@ -89,12 +89,12 @@ myopen(FetchData *fetch_data, GError **error)
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, cwrite_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, fetch_data->istream);
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, fetch_data->curl_error_buf);
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
     g_free(uri);
 
     if (fetch_data->ssl_verify == FALSE) {
-        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
     }
 
     res = curl_multi_add_handle(curlm, curl);


### PR DESCRIPTION
The directory was changed from /var/lib/restraint already. So, the restraint-rhts-set script should follow the change.

Related: b3bffb90d46a5ec5a1699a5ce9100ea13fc7f003
Related: https://github.com/restraint-harness/restraint/issues/336