### PR TITLE
Fix PackIt's tarball name to match tito's tarball name

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,6 +12,12 @@ upstream_package_name: restraint
 # downstream (Fedora) RPM package name
 downstream_package_name: restraint
 
+actions:
+  get-current-version:
+    # Override git tag and match what Tito uses
+    # The cut is for "restraint-0.4.11-<git stuff>" -> 0.4.11
+    - bash -c "git describe|cut -d'-' -f2"
+
 # Valid metadata targets can be check by command
 # copr list-chroots
 jobs:


### PR DESCRIPTION
Tito creates a tarball/rpm that says 'restraint-0.4.11', whereas PackIt uses <name>-<git tag> and creates 'restraint-restraint-0.4.11'.  This makes it hard to 'dnf update restraint' to use PackIt's rpm on top of the official Tito built rpm because restraint-0.4.11 > restraint-restraint-0.4.11.<packit extra>.prxxx.

Let's align the tarballs so we can use PackIt's rpm as a natural dnf update to the one in the provisioner allowing for CI tests.