### PR TITLE
When using rpm-ostree, it is necessary to check whether each package is installed individually and only install the packages that do not exist

### DIFF
--- a/plugins/pkg_commands.d/centos
+++ b/plugins/pkg_commands.d/centos
@@ -5,8 +5,8 @@
 if [ -f "/run/ostree-booted" ];then
     # OSTree based filesystems are read-only and install with rpm-ostree
     RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-rpm-ostree}
-    RSTRNT_PKG_ARGS=${RSTRNT_PKG_ARGS:--y --idempotent --allow-inactive}
-    RSTRNT_PKG_INSTALL=${RSTRNT_PKG_INSTALL:-install --apply-live}
+    RSTRNT_PKG_ARGS=${RSTRNT_PKG_ARGS:-' '}
+    RSTRNT_PKG_INSTALL=${RSTRNT_PKG_INSTALL:-install -y --idempotent --allow-inactive --apply-live}
 elif [ 0"$(echo $VERSION_ID | cut -d'.' -f1)" -ge 8 ]; then
     # CentOS 8 and newer use dnf as default
     RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-dnf}

--- a/plugins/pkg_commands.d/fedora
+++ b/plugins/pkg_commands.d/fedora
@@ -5,8 +5,8 @@
 if [ -f "/run/ostree-booted" ]; then
     # OSTree based filesystems are read-only and install with rpm-ostree
     RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-rpm-ostree}
-    RSTRNT_PKG_ARGS=${RSTRNT_PKG_ARGS:--y --idempotent --allow-inactive}
-    RSTRNT_PKG_INSTALL=${RSTRNT_PKG_INSTALL:-install --apply-live}
+    RSTRNT_PKG_ARGS=${RSTRNT_PKG_ARGS:-' '}
+    RSTRNT_PKG_INSTALL=${RSTRNT_PKG_INSTALL:-install -y --idempotent --allow-inactive --apply-live}
 elif [ 0"$VERSION_ID" -gt 21 ]; then
     # Fedora 22 and newer use dnf as default
     RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-dnf}

--- a/plugins/pkg_commands.d/rhel
+++ b/plugins/pkg_commands.d/rhel
@@ -5,8 +5,8 @@
 if [ -f "/run/ostree-booted" ];then
     # OSTree based filesystems are read-only and install with rpm-ostree
     RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-rpm-ostree}
-    RSTRNT_PKG_ARGS=${RSTRNT_PKG_ARGS:--y --idempotent --allow-inactive}
-    RSTRNT_PKG_INSTALL=${RSTRNT_PKG_INSTALL:-install --apply-live}
+    RSTRNT_PKG_ARGS=${RSTRNT_PKG_ARGS:-' '}
+    RSTRNT_PKG_INSTALL=${RSTRNT_PKG_INSTALL:-install -y --idempotent --allow-inactive --apply-live}
 elif [ 0"$(echo $VERSION_ID | cut -d'.' -f1)" -ge 8 ]; then
     # RHEL 8 and newer use dnf as default
     RSTRNT_PKG_CMD=${RSTRNT_PKG_CMD:-dnf}

--- a/scripts/rstrnt-package
+++ b/scripts/rstrnt-package
@@ -63,12 +63,39 @@ _pkg_cmd() {
     return $success
 }
 
+_ostree_cmd() {
+    opr=$1
+    success=0
+    try=0
+    for package in "${packages[@]}"; do
+        if ! rpm -q --whatprovides "${package}"; then
+            while [ $try -lt $retry ]; do
+                echo "[run] $pkg_cmd $pkg_args $opr $package"
+                $pkg_cmd $pkg_args $opr $package
+                if [ $? -eq 0 ]; then
+                    success=0
+                    break 1
+                fi
+                sleep $delay
+                let try+=1
+            done
+        fi
+    done
+
+    return $success
+}
+
 if [ "$operation" = "install" ]; then
-    _pkg_cmd "$pkg_install"
-    RC=$?
-    if [[ $RC == 0 && $pkg_cmd == "yum" ]]; then
-       rpm -q --whatprovides $package
-       RC=$?
+    if [ "$pkg_cmd" = "rpm-ostree" ]; then
+        read -r -a packages <<<"${package}"
+        _ostree_cmd "$pkg_install"
+    else
+        _pkg_cmd "$pkg_install"
+        RC=$?
+        if [[ $RC == 0 && $pkg_cmd == "yum" ]]; then
+           rpm -q --whatprovides $package
+           RC=$?
+        fi
     fi
 elif [ "$operation" = "remove" ]; then
     _pkg_cmd "$pkg_remove"

--- a/tests/test-dummies/fakeyum
+++ b/tests/test-dummies/fakeyum
@@ -2,8 +2,21 @@
 
 # A dummy "implementation" of yum for tests.
 
-if [[ "$*" == -y\ install\ * ]] ; then
-    shift 2
+# Collect options and positional parameters separately
+opts=() # Store options such as -x or --xx
+args=() # Store the actual subcommand/package name
+for a in "$@"; do
+    case "$a" in
+        -*) opts+=("$a") ;;   # add options
+        *) args+=("$a") ;;
+    esac
+done
+
+# rebuild positional args
+set -- "${args[@]}"
+
+if [[ "$1" == install ]]; then
+    shift
     if [[ "$*" == *fail* ]] ; then
         echo "dummy yum: fail" >&2
         # Something is wrong with GIO - without the sleep we sometimes don't get 
@@ -15,6 +28,19 @@ if [[ "$*" == -y\ install\ * ]] ; then
     # Something is wrong with GIO - without the sleep we sometimes don't get 
     # the last line of data.
     sleep .11
+    exit 0
+fi
+
+if [[ "$1" == "download" ]]; then
+    for opt in "${OPTS[@]}"; do
+        if [[ "$opt" =~ ^--destdir=(.*) ]]; then
+            tmpdir="${BASH_REMATCH[1]}"
+            shift
+            for pkg in "$@"; do
+                touch "$tmpdir/$pkg"
+            done
+        fi
+    done
     exit 0
 fi
 


### PR DESCRIPTION
Even if some packages have been installed in baseos, rpm-ostree will fail to install them again.

For example wget already install in OS. but using rpm-ostree install would failed.
```
[root@hp-dl388g10-03 ~]# rpm -q wget 
wget-1.21.1-8.el9_4.x86_64
[root@hp-dl388g10-03 ~]# rpm-ostree install -y --idempotent --allow-inactive  wget
Inactive requests:
  efibootmgr (already provided by efibootmgr-16-12.el9.x86_64)
Checking out tree 3d7d736... done
Enabled rpm-md repositories: beaker-AppStream-debuginfo beaker-AppStream beaker-BaseOS-debuginfo beaker-BaseOS beaker-CRB-debuginfo beaker-CRB beaker-HighAvailability-debuginfo beaker-HighAvailability beaker-NFV-debuginfo beaker-NFV beaker-RT-debuginfo beaker-RT beaker-SAP-debuginfo beaker-SAP beaker-SAPHANA-debuginfo beaker-SAPHANA beaker-buildroot beaker-harness
Importing rpm-md... done
rpm-md repo 'beaker-AppStream-debuginfo' (cached); generated: 2025-09-22T04:59:05Z solvables: 4594
rpm-md repo 'beaker-AppStream' (cached); generated: 2025-09-22T04:59:04Z solvables: 6356
rpm-md repo 'beaker-BaseOS-debuginfo' (cached); generated: 2025-09-22T04:59:27Z solvables: 1428
rpm-md repo 'beaker-BaseOS' (cached); generated: 2025-09-22T04:59:24Z solvables: 1180
rpm-md repo 'beaker-CRB-debuginfo' (cached); generated: 2025-09-22T04:59:44Z solvables: 515
rpm-md repo 'beaker-CRB' (cached); generated: 2025-09-22T04:59:46Z solvables: 2038
rpm-md repo 'beaker-HighAvailability-debuginfo' (cached); generated: 2025-09-22T04:59:57Z solvables: 27
rpm-md repo 'beaker-HighAvailability' (cached); generated: 2025-09-22T04:59:57Z solvables: 44
rpm-md repo 'beaker-NFV-debuginfo' (cached); generated: 2025-09-22T05:00:03Z solvables: 2
rpm-md repo 'beaker-NFV' (cached); generated: 2025-09-22T05:00:00Z solvables: 19
rpm-md repo 'beaker-RT-debuginfo' (cached); generated: 2025-09-22T05:00:12Z solvables: 2
rpm-md repo 'beaker-RT' (cached); generated: 2025-09-22T05:00:12Z solvables: 16
rpm-md repo 'beaker-SAP-debuginfo' (cached); generated: 2025-09-22T05:00:31Z solvables: 12
rpm-md repo 'beaker-SAP' (cached); generated: 2025-09-22T05:00:31Z solvables: 10
rpm-md repo 'beaker-SAPHANA-debuginfo' (cached); generated: 2025-09-22T05:00:40Z solvables: 10
rpm-md repo 'beaker-SAPHANA' (cached); generated: 2025-09-22T05:00:38Z solvables: 10
rpm-md repo 'beaker-buildroot' (cached); generated: 2025-09-27T06:24:40Z solvables: 1912
rpm-md repo 'beaker-harness' (cached); generated: 2025-07-08T16:28:30Z solvables: 174
Resolving dependencies... done
error: No packages in transaction
```
But on the other hand, if install vim, rpm-ostree work as design.
```
[root@hp-dl388g10-03 ~]# rpm-ostree install -y --idempotent --allow-inactive  vim
Inactive requests:
  efibootmgr (already provided by efibootmgr-16-12.el9.x86_64)
Checking out tree 3d7d736... done
Enabled rpm-md repositories: beaker-AppStream-debuginfo beaker-AppStream beaker-BaseOS-debuginfo beaker-BaseOS beaker-CRB-debuginfo beaker-CRB beaker-HighAvailability-debuginfo beaker-HighAvailability beaker-NFV-debuginfo beaker-NFV beaker-RT-debuginfo beaker-RT beaker-SAP-debuginfo beaker-SAP beaker-SAPHANA-debuginfo beaker-SAPHANA beaker-buildroot beaker-harness
Importing rpm-md... done
rpm-md repo 'beaker-AppStream-debuginfo' (cached); generated: 2025-09-22T04:59:05Z solvables: 4594
rpm-md repo 'beaker-AppStream' (cached); generated: 2025-09-22T04:59:04Z solvables: 6356
rpm-md repo 'beaker-BaseOS-debuginfo' (cached); generated: 2025-09-22T04:59:27Z solvables: 1428
rpm-md repo 'beaker-BaseOS' (cached); generated: 2025-09-22T04:59:24Z solvables: 1180
rpm-md repo 'beaker-CRB-debuginfo' (cached); generated: 2025-09-22T04:59:44Z solvables: 515
rpm-md repo 'beaker-CRB' (cached); generated: 2025-09-22T04:59:46Z solvables: 2038
rpm-md repo 'beaker-HighAvailability-debuginfo' (cached); generated: 2025-09-22T04:59:57Z solvables: 27
rpm-md repo 'beaker-HighAvailability' (cached); generated: 2025-09-22T04:59:57Z solvables: 44
rpm-md repo 'beaker-NFV-debuginfo' (cached); generated: 2025-09-22T05:00:03Z solvables: 2
rpm-md repo 'beaker-NFV' (cached); generated: 2025-09-22T05:00:00Z solvables: 19
rpm-md repo 'beaker-RT-debuginfo' (cached); generated: 2025-09-22T05:00:12Z solvables: 2
rpm-md repo 'beaker-RT' (cached); generated: 2025-09-22T05:00:12Z solvables: 16
rpm-md repo 'beaker-SAP-debuginfo' (cached); generated: 2025-09-22T05:00:31Z solvables: 12
rpm-md repo 'beaker-SAP' (cached); generated: 2025-09-22T05:00:31Z solvables: 10
rpm-md repo 'beaker-SAPHANA-debuginfo' (cached); generated: 2025-09-22T05:00:40Z solvables: 10
rpm-md repo 'beaker-SAPHANA' (cached); generated: 2025-09-22T05:00:38Z solvables: 10
rpm-md repo 'beaker-buildroot' (cached); generated: 2025-09-27T06:24:40Z solvables: 1912
rpm-md repo 'beaker-harness' (cached); generated: 2025-07-08T16:28:30Z solvables: 174
Resolving dependencies... done
Will download: 4 packages (9.2 MB)
Downloading from 'beaker-BaseOS'... done
Downloading from 'beaker-AppStream'... done
Importing packages... done
Checking out packages... done
Running pre scripts... done
Running post scripts... done
Running posttrans scripts... done
Writing rpmdb... done
Writing OSTree commit... done
Staging deployment... done
Added:
  gpm-libs-1.20.7-29.el9.x86_64
  vim-common-2:8.2.2637-22.el9_6.x86_64
  vim-enhanced-2:8.2.2637-22.el9_6.x86_64
  vim-filesystem-2:8.2.2637-22.el9_6.noarch
Changes queued for next boot. Run "systemctl reboot" to start a reboot
[root@hp-dl388g10-03 ~]# rpm-ostree install -y --idempotent --allow-inactive  vim
Inactive requests:
  efibootmgr (already provided by efibootmgr-16-12.el9.x86_64)
Checking out tree 3d7d736... done
Enabled rpm-md repositories: beaker-AppStream-debuginfo beaker-AppStream beaker-BaseOS-debuginfo beaker-BaseOS beaker-CRB-debuginfo beaker-CRB beaker-HighAvailability-debuginfo beaker-HighAvailability beaker-NFV-debuginfo beaker-NFV beaker-RT-debuginfo beaker-RT beaker-SAP-debuginfo beaker-SAP beaker-SAPHANA-debuginfo beaker-SAPHANA beaker-buildroot beaker-harness
Importing rpm-md... done
rpm-md repo 'beaker-AppStream-debuginfo' (cached); generated: 2025-09-22T04:59:05Z solvables: 4594
rpm-md repo 'beaker-AppStream' (cached); generated: 2025-09-22T04:59:04Z solvables: 6356
rpm-md repo 'beaker-BaseOS-debuginfo' (cached); generated: 2025-09-22T04:59:27Z solvables: 1428
rpm-md repo 'beaker-BaseOS' (cached); generated: 2025-09-22T04:59:24Z solvables: 1180
rpm-md repo 'beaker-CRB-debuginfo' (cached); generated: 2025-09-22T04:59:44Z solvables: 515
rpm-md repo 'beaker-CRB' (cached); generated: 2025-09-22T04:59:46Z solvables: 2038
rpm-md repo 'beaker-HighAvailability-debuginfo' (cached); generated: 2025-09-22T04:59:57Z solvables: 27
rpm-md repo 'beaker-HighAvailability' (cached); generated: 2025-09-22T04:59:57Z solvables: 44
rpm-md repo 'beaker-NFV-debuginfo' (cached); generated: 2025-09-22T05:00:03Z solvables: 2
rpm-md repo 'beaker-NFV' (cached); generated: 2025-09-22T05:00:00Z solvables: 19
rpm-md repo 'beaker-RT-debuginfo' (cached); generated: 2025-09-22T05:00:12Z solvables: 2
rpm-md repo 'beaker-RT' (cached); generated: 2025-09-22T05:00:12Z solvables: 16
rpm-md repo 'beaker-SAP-debuginfo' (cached); generated: 2025-09-22T05:00:31Z solvables: 12
rpm-md repo 'beaker-SAP' (cached); generated: 2025-09-22T05:00:31Z solvables: 10
rpm-md repo 'beaker-SAPHANA-debuginfo' (cached); generated: 2025-09-22T05:00:40Z solvables: 10
rpm-md repo 'beaker-SAPHANA' (cached); generated: 2025-09-22T05:00:38Z solvables: 10
rpm-md repo 'beaker-buildroot' (cached); generated: 2025-09-27T06:24:40Z solvables: 1912
rpm-md repo 'beaker-harness' (cached); generated: 2025-07-08T16:28:30Z solvables: 174
Resolving dependencies... done
No change.

```
